### PR TITLE
fix: updated branch name linter

### DIFF
--- a/.github/workflows/branch_name_linters.yaml
+++ b/.github/workflows/branch_name_linters.yaml
@@ -13,3 +13,4 @@ jobs:
         uses: aschbacd/gitlint-action@v1.2.0
         with:
           re-branch-name: ^(feature|bugfix|hotfix|release|docs)\/.+$
+          re-commit-message-subject: .*


### PR DESCRIPTION
commit body now won't be checked